### PR TITLE
Add front-end skeleton and GH Pages deployment

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,30 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload front-end
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: front-end
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Invoice Management</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-AigLvs9rqsHMvFvA2sPbhCPKfd5W2BtWMpTrBm16SrE1+E1L5aS2+DeVRRJ1Cr9E"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div class="container py-5">
+      <h1 class="mb-3">Invoice Dashboard</h1>
+      <button id="send-btn" class="btn btn-primary">Send Data</button>
+      <button id="load-btn" class="btn btn-secondary ms-2">Load Data</button>
+      <pre id="output" class="mt-4"></pre>
+    </div>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-FE1vzzUMsQ9iDUn30T+yecnP+X7iYsJhBKt3vnDnNQfXlBx/OVCkXbkqXA67R9Oj"
+      crossorigin="anonymous"
+    ></script>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/front-end/main.js
+++ b/front-end/main.js
@@ -1,0 +1,55 @@
+// @flow
+
+// Example of calling Google Apps Script functions.
+// These functions assume the page is running inside an Apps Script web app.
+
+function sendData(): void {
+  const payload = { message: 'Hello from the client!' };
+  // google.script.run will invoke the Apps Script function named 'processData'.
+  google.script
+    .run
+    .withSuccessHandler(() => {
+      const output = document.getElementById('output');
+      if (output) {
+        output.textContent = 'Data sent successfully.';
+      }
+    })
+    .withFailureHandler((err) => {
+      const output = document.getElementById('output');
+      if (output) {
+        output.textContent = 'Error: ' + err.message;
+      }
+    })
+    .processData(payload);
+}
+
+function loadData(): void {
+  // google.script.run will invoke the Apps Script function named 'fetchData'.
+  google.script
+    .run
+    .withSuccessHandler((data) => {
+      const output = document.getElementById('output');
+      if (output) {
+        output.textContent = JSON.stringify(data, null, 2);
+      }
+    })
+    .withFailureHandler((err) => {
+      const output = document.getElementById('output');
+      if (output) {
+        output.textContent = 'Error: ' + err.message;
+      }
+    })
+    .fetchData();
+}
+
+// Attach event listeners once DOM is ready.
+document.addEventListener('DOMContentLoaded', () => {
+  const sendBtn = document.getElementById('send-btn');
+  const loadBtn = document.getElementById('load-btn');
+  if (sendBtn) {
+    sendBtn.addEventListener('click', sendData);
+  }
+  if (loadBtn) {
+    loadBtn.addEventListener('click', loadData);
+  }
+});


### PR DESCRIPTION
## Summary
- create `index.html` with Bootstrap 5
- add `main.js` showing `google.script.run` usage
- enable GitHub Pages workflow

## Testing
- `npm --silent --version`
- `node -e "console.log('Node is available')"`


------
https://chatgpt.com/codex/tasks/task_e_688ac1855d288329987b1c3893ed837a