### PR TITLE
Setup triggers and basic API

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -14,12 +14,13 @@ function onOpen() {
     .addItem("Run Monthly Billing", "runMonthlyBilling")
     .addItem("Issue NFSe", "issueNFSe")
     .addToUi();
+  ensureTriggers();
 }
 
 /**
  * Registers time-driven triggers for monthly billing and overdue updates.
  */
-function registerTriggers() {
+function createTriggers() {
   ScriptApp.newTrigger("runMonthlyBilling")
     .timeBased()
     .onMonthDay(1)
@@ -30,4 +31,99 @@ function registerTriggers() {
     .onWeekDay(ScriptApp.WeekDay.MONDAY)
     .atHour(3)
     .create();
+}
+
+/**
+ * Ensures required triggers exist before running automation.
+ */
+function ensureTriggers() {
+  var triggers = ScriptApp.getProjectTriggers();
+  var hasBilling = false;
+  var hasDashboards = false;
+  var hasEdit = false;
+  triggers.forEach(function (t) {
+    if (
+      t.getHandlerFunction() === "runMonthlyBilling" &&
+      t.getEventType() === ScriptApp.EventType.CLOCK
+    ) {
+      hasBilling = true;
+    }
+    if (
+      t.getHandlerFunction() === "refreshDashboards" &&
+      t.getEventType() === ScriptApp.EventType.CLOCK
+    ) {
+      hasDashboards = true;
+    }
+    if (
+      t.getHandlerFunction() === "addService" &&
+      t.getEventType() === ScriptApp.EventType.ON_EDIT
+    ) {
+      hasEdit = true;
+    }
+  });
+
+  if (!hasBilling || !hasDashboards) {
+    createTriggers();
+  }
+
+  if (!hasEdit) {
+    ScriptApp.newTrigger("addService")
+      .forSpreadsheet(SpreadsheetApp.getActive())
+      .onEdit()
+      .create();
+  }
+}
+
+/**
+ * Returns sheet data as JSON.
+ * @param {string} name Sheet name.
+ * @return {GoogleAppsScript.Content.TextOutput} JSON output.
+ * @private
+ */
+function sheetToJson_(name) {
+  var ss = SpreadsheetApp.getActive();
+  var sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    return ContentService.createTextOutput("[]").setMimeType(
+      ContentService.MimeType.JSON
+    );
+  }
+  var data = sheet.getDataRange().getValues();
+  if (data.length === 0) {
+    return ContentService.createTextOutput("[]").setMimeType(
+      ContentService.MimeType.JSON
+    );
+  }
+  var headers = data.shift();
+  var obj = data.map(function (row) {
+    var out = {};
+    headers.forEach(function (h, i) {
+      out[String(h)] = row[i];
+    });
+    return out;
+  });
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(
+    ContentService.MimeType.JSON
+  );
+}
+
+/**
+ * Main GET handler returning JSON for project endpoints.
+ * @param {GoogleAppsScript.Events.DoGet} e Event object.
+ * @return {GoogleAppsScript.Content.TextOutput} JSON output.
+ */
+function doGet(e) {
+  var path = e && e.pathInfo ? String(e.pathInfo).replace(/^\//, "") : "";
+  switch (path) {
+    case "machines":
+      return sheetToJson_("Machines");
+    case "services":
+      return sheetToJson_("Services");
+    case "invoices":
+      return sheetToJson_("Invoices");
+    default:
+      return ContentService.createTextOutput("{}").setMimeType(
+        ContentService.MimeType.JSON
+      );
+  }
 }


### PR DESCRIPTION
## Summary
- ensure triggers for monthly billing, dashboard refresh and sheet editing
- expose spreadsheet data via JSON endpoints

## Testing
- `npx eslint src/Code.gs` *(fails: ENOTFOUND registry.npmjs.org)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ac378c63c8329abc0285290e4d025