### PR TITLE
Load script properties for tokens

### DIFF
--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -22,7 +22,13 @@ Ensure that Node.js **20.19.0** is installed locally. Development tools expect a
    - `runMonthlyBilling` – Time-driven, 1st of the month, 02:00.
    - `updateOverdueStatus` – Time-driven, Daily, 01:00.
 
-## 4. Test Invoice Cycle
+## 4. Configure Script Properties
+1. In the Apps Script editor open **Project Settings → Script Properties**.
+2. Add the following key/value pairs:
+   - `NFSE_TOKEN` – your PlugNotas API token.
+   - `PIX_QR_URL` – URL of the PIX QR code image (optional).
+
+## 5. Test Invoice Cycle
 1. Add sample data to the `Clients`, `Machines` and `BillingConfig` sheets.
 2. Click **Run → runMonthlyBilling** in the Apps Script editor.
 3. Verify that a PDF invoice is generated in your Drive and emailed to the client.

--- a/invoice_automation_blueprint.md
+++ b/invoice_automation_blueprint.md
@@ -61,9 +61,19 @@ const CONFIG = {
   CNPJ: '54566671000143',
   IM: '13006525',
   PDF_FOLDER_ID: '1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh',
-  NFSE_TOKEN: '<<PLACE_YOUR_NFSE_TOKEN>>',
   COLOR_BLUE: '#003B70'
 };
+
+// Fetch sensitive tokens from Script Properties
+var SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
+
+function getNFSeToken() {
+  return SCRIPT_PROPERTIES.getProperty('NFSE_TOKEN');
+}
+
+function getPixQrUrl() {
+  return SCRIPT_PROPERTIES.getProperty('PIX_QR_URL');
+}
 ```
 
 ### 3.2  Setup Functions

--- a/src/Billing.gs
+++ b/src/Billing.gs
@@ -156,9 +156,10 @@ function generateInvoicePDF(invoiceId, itemsTable, total, clientId) {
   body.replaceText("{{ContactName}}", clientRow ? clientRow[3] : "");
   body.replaceText("{{ContactEmail}}", clientRow ? clientRow[5] : "");
   body.replaceText("{{LineItemsTable}}", itemsTable);
-  if (CONFIG.PIX_QR_URL) {
+  var qrUrl = getPixQrUrl();
+  if (qrUrl) {
     try {
-      var img = UrlFetchApp.fetch(CONFIG.PIX_QR_URL).getBlob();
+      var img = UrlFetchApp.fetch(qrUrl).getBlob();
       body.appendImage(img);
     } catch (e) {
       Logger.log("Failed to fetch QR code: " + e);

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -10,7 +10,24 @@ var CONFIG = {
   CNPJ: "54566671000143",
   IM: "13006525",
   PDF_FOLDER_ID: "1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh",
-  NFSE_TOKEN: "<<PLACE_YOUR_NFSE_TOKEN>>",
-  COLOR_BLUE: "#003B70",
-  PIX_QR_URL: ""
+  COLOR_BLUE: "#003B70"
 };
+
+// Lazily load sensitive values from Script Properties
+var SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
+
+/**
+ * Returns the NFSe API token stored in Script Properties.
+ * @return {string?} token value or null if not set
+ */
+function getNFSeToken() {
+  return SCRIPT_PROPERTIES.getProperty("NFSE_TOKEN");
+}
+
+/**
+ * Returns the PIX QR code URL stored in Script Properties.
+ * @return {string?} QR code image URL or null if not set
+ */
+function getPixQrUrl() {
+  return SCRIPT_PROPERTIES.getProperty("PIX_QR_URL");
+}

--- a/src/NFSe.gs
+++ b/src/NFSe.gs
@@ -17,7 +17,7 @@ function issueNFSe(invoiceId) {
   for (var i = 1; i < data.length; i++) {
     if (String(data[i][0]) === String(invoiceId)) {
       var payload = {
-        token: CONFIG.NFSE_TOKEN,
+        token: getNFSeToken(),
         invoice: data[i]
       };
       var options = {


### PR DESCRIPTION
## Summary
- read NFSe token and PIX QR URL from Apps Script properties
- document how to set script properties manually
- update example blueprint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9bfbd308329a66257798eb63a8c