### PR TITLE
Introduce CONFIG.SHEETS constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # MyInvoice
 
-This project automates invoice management using Google Apps Script and a simple web front end.  
+This project automates invoice management using Google Apps Script and a simple web front end.
 Node.js `20.19.0` is required to ensure compatibility with tooling. Other Node 20 versions may work, but the recommended range is `>=18 <=20`.
+
+The Apps Script portion exposes a global `CONFIG` object for customization. A new
+`CONFIG.SHEETS` field lists the spreadsheet tabs used by the system. Refer to
+these constants instead of string literals when accessing sheets in code.

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -27,5 +27,10 @@ Ensure that Node.js **20.19.0** is installed locally. Development tools expect a
 2. Click **Run → runMonthlyBilling** in the Apps Script editor.
 3. Verify that a PDF invoice is generated in your Drive and emailed to the client.
 
+### Tips
+
+Sheet names are defined in `Config.gs` under `CONFIG.SHEETS`. If you rename a
+tab, update the corresponding constant.
+
 ## Screenshots
 Include screenshots of the Apps Script editor showing how to add triggers and a GIF of a test invoice run. Save them under the `docs/images` directory.

--- a/src/Billing.gs
+++ b/src/Billing.gs
@@ -4,10 +4,10 @@
  */
 function runMonthlyBilling() {
   var ss = SpreadsheetApp.getActive();
-  var machinesSheet = ss.getSheetByName("Machines");
-  var servicesSheet = ss.getSheetByName("Services");
-  var invoicesSheet = ss.getSheetByName("Invoices");
-  var clientsSheet = ss.getSheetByName("Clients");
+  var machinesSheet = ss.getSheetByName(CONFIG.SHEETS.MACHINES);
+  var servicesSheet = ss.getSheetByName(CONFIG.SHEETS.SERVICES);
+  var invoicesSheet = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
+  var clientsSheet = ss.getSheetByName(CONFIG.SHEETS.CLIENTS);
 
   if (!machinesSheet || !servicesSheet || !invoicesSheet || !clientsSheet) {
     SpreadsheetApp.getUi().alert("Missing sheets. Run ensureSheets first.");
@@ -102,8 +102,8 @@ function runMonthlyBilling() {
  */
 function generateInvoicePDF(invoiceId, itemsTable, total, clientId) {
   var ss = SpreadsheetApp.getActive();
-  var clientsSheet = ss.getSheetByName("Clients");
-  var invoicesSheet = ss.getSheetByName("Invoices");
+  var clientsSheet = ss.getSheetByName(CONFIG.SHEETS.CLIENTS);
+  var invoicesSheet = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
   var data = clientsSheet.getDataRange().getValues();
   var clientRow;
   for (var i = 1; i < data.length; i++) {

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -116,11 +116,11 @@ function doGet(e) {
   var path = e && e.pathInfo ? String(e.pathInfo).replace(/^\//, "") : "";
   switch (path) {
     case "machines":
-      return sheetToJson_("Machines");
+      return sheetToJson_(CONFIG.SHEETS.MACHINES);
     case "services":
-      return sheetToJson_("Services");
+      return sheetToJson_(CONFIG.SHEETS.SERVICES);
     case "invoices":
-      return sheetToJson_("Invoices");
+      return sheetToJson_(CONFIG.SHEETS.INVOICES);
     default:
       return ContentService.createTextOutput("{}").setMimeType(
         ContentService.MimeType.JSON

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -12,5 +12,13 @@ var CONFIG = {
   PDF_FOLDER_ID: "1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh",
   NFSE_TOKEN: "<<PLACE_YOUR_NFSE_TOKEN>>",
   COLOR_BLUE: "#003B70",
-  PIX_QR_URL: ""
+  PIX_QR_URL: "",
+  SHEETS: {
+    MACHINES: "Machines",
+    SERVICES: "Services",
+    BILLING_CONFIG: "BillingConfig",
+    CLIENTS: "Clients",
+    INVOICES: "Invoices",
+    DASHBOARDS: "Dashboards"
+  }
 };

--- a/src/NFSe.gs
+++ b/src/NFSe.gs
@@ -9,7 +9,7 @@ function issueNFSe(invoiceId) {
     return;
   }
   var ss = SpreadsheetApp.getActive();
-  var invoices = ss.getSheetByName("Invoices");
+  var invoices = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
   if (!invoices) {
     return;
   }

--- a/src/ServiceHooks.gs
+++ b/src/ServiceHooks.gs
@@ -4,7 +4,11 @@
  * @param {GoogleAppsScript.Events.SheetsOnEdit} e Edit event object.
  */
 function addService(e) {
-  if (!e || !e.range || e.range.getSheet().getName() !== "Services") {
+  if (
+    !e ||
+    !e.range ||
+    e.range.getSheet().getName() !== CONFIG.SHEETS.SERVICES
+  ) {
     return;
   }
   var sheet = e.range.getSheet();
@@ -13,7 +17,9 @@ function addService(e) {
   if (!serviceType) {
     return;
   }
-  var configSheet = SpreadsheetApp.getActive().getSheetByName("BillingConfig");
+  var configSheet = SpreadsheetApp.getActive().getSheetByName(
+    CONFIG.SHEETS.BILLING_CONFIG
+  );
   if (!configSheet) {
     return;
   }

--- a/src/SheetsUtil.gs
+++ b/src/SheetsUtil.gs
@@ -11,59 +11,63 @@
  */
 function ensureSheets() {
   var ss = SpreadsheetApp.getActive();
-  var sheetSpecs = {
-    Machines: [
-      "Serial",
-      "Model",
-      "ClientID",
-      "StorageRate",
-      "DateIn",
-      "DateOut",
-      "Status",
-      "LastBilledThrough"
-    ],
-    Services: [
-      "ServiceID",
-      "Serial",
-      "ClientID",
-      "ServiceDate",
-      "ServiceType",
-      "Description",
-      "UnitPrice",
-      "QtyHours",
-      "TotalPrice",
-      "Billed"
-    ],
-    BillingConfig: ["ServiceType", "UnitPrice", "DefaultTax%"],
-    Clients: [
-      "ClientID",
-      "Name",
-      "Address",
-      "ContactName",
-      "ContactPosition",
-      "ContactEmail",
-      "ContactPhone",
-      "TaxID/CNPJ",
-      "Export"
-    ],
-    Invoices: [
-      "InvoiceID",
-      "ClientID",
-      "PeriodStart",
-      "PeriodEnd",
-      "IssueDate",
-      "DueDate",
-      "Total",
-      "Paid",
-      "PaymentDate",
-      "Overdue",
-      "PDFLink",
-      "NFSeNumber",
-      "NFSeType",
-      "LineItemsJSON"
-    ],
-    Dashboards: []
-  };
+  var sheetSpecs = {};
+  sheetSpecs[CONFIG.SHEETS.MACHINES] = [
+    "Serial",
+    "Model",
+    "ClientID",
+    "StorageRate",
+    "DateIn",
+    "DateOut",
+    "Status",
+    "LastBilledThrough"
+  ];
+  sheetSpecs[CONFIG.SHEETS.SERVICES] = [
+    "ServiceID",
+    "Serial",
+    "ClientID",
+    "ServiceDate",
+    "ServiceType",
+    "Description",
+    "UnitPrice",
+    "QtyHours",
+    "TotalPrice",
+    "Billed"
+  ];
+  sheetSpecs[CONFIG.SHEETS.BILLING_CONFIG] = [
+    "ServiceType",
+    "UnitPrice",
+    "DefaultTax%"
+  ];
+  sheetSpecs[CONFIG.SHEETS.CLIENTS] = [
+    "ClientID",
+    "Name",
+    "Address",
+    "ContactName",
+    "ContactPosition",
+    "ContactEmail",
+    "ContactPhone",
+    "TaxID/CNPJ",
+    "Export"
+  ];
+  sheetSpecs[CONFIG.SHEETS.INVOICES] = [
+    "InvoiceID",
+    "ClientID",
+    "PeriodStart",
+    "PeriodEnd",
+    "IssueDate",
+    "DueDate",
+    "Total",
+    "Paid",
+    "PaymentDate",
+    "Overdue",
+    "PDFLink",
+    "NFSeNumber",
+    "NFSeType",
+    "LineItemsJSON"
+  ];
+  sheetSpecs[CONFIG.SHEETS.DASHBOARDS] = [];
+
   Object.keys(sheetSpecs).forEach(function (name) {
     var sheet = ss.getSheetByName(name);
     if (!sheet) {
@@ -110,7 +114,7 @@ function ensureTemplateDoc() {
  */
 function refreshDashboards() {
   var ss = SpreadsheetApp.getActive();
-  var sheet = ss.getSheetByName("Dashboards");
+  var sheet = ss.getSheetByName(CONFIG.SHEETS.DASHBOARDS);
   if (!sheet) {
     return;
   }
@@ -119,12 +123,16 @@ function refreshDashboards() {
   sheet
     .getRange("A1")
     .setFormula(
-      "=QUERY(Invoices!A:K,\"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'\",1)"
+      "=QUERY(" +
+        CONFIG.SHEETS.INVOICES +
+        "!A:K,\"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'\",1)"
     );
   sheet
     .getRange("E1")
     .setFormula(
-      "=QUERY(Services!A:J,\"select year(ServiceDate), month(ServiceDate), sum(TotalPrice) where Billed='YES' group by 1,2 label sum(TotalPrice) 'ServiceCosts'\",1)"
+      "=QUERY(" +
+        CONFIG.SHEETS.SERVICES +
+        "!A:J,\"select year(ServiceDate), month(ServiceDate), sum(TotalPrice) where Billed='YES' group by 1,2 label sum(TotalPrice) 'ServiceCosts'\",1)"
     );
   var chart = sheet
     .newChart()


### PR DESCRIPTION
## Summary
- centralise sheet names under CONFIG.SHEETS
- update Apps Script files to reference CONFIG.SHEETS
- document the new constants in README and setup guide

## Testing
- `npx eslint src front-end` *(fails: eslint not installed)*
- `npx prettier -c "src/**/*.gs" "front-end/*.js"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9c1695483299dbd0d38f2796f91