### PR TITLE
Add QUnit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # MyInvoice
 
-This project automates invoice management using Google Apps Script and a simple web front end.  
+This project automates invoice management using Google Apps Script and a simple web front end.
 Node.js `20.19.0` is required to ensure compatibility with tooling. Other Node 20 versions may work, but the recommended range is `>=18 <=20`.
+
+## Running Tests in Apps Script
+
+1. Upload the contents of the `tests/` directory to your Apps Script project.
+2. Open the **Extensions → Apps Script** editor from the spreadsheet.
+3. Select **QUnit** from the "Select function" dropdown and click **Run**.
+4. Check the logs/output panel for test results.

--- a/tests/Billing.test.gs
+++ b/tests/Billing.test.gs
@@ -1,0 +1,64 @@
+// @flow
+/**
+ * QUnit tests for Billing functions.
+ */
+function BillingTestSuite() {
+  QUnit.module("Billing");
+
+  QUnit.test("generateInvoicePDF creates PDF link", function (assert) {
+    var ss = SpreadsheetApp.getActive();
+    ensureSheets();
+    var invoices = ss.getSheetByName("Invoices");
+    invoices.clearContents();
+    invoices.appendRow([
+      "InvoiceID",
+      "ClientID",
+      "PeriodStart",
+      "PeriodEnd",
+      "IssueDate",
+      "DueDate",
+      "Total",
+      "Paid",
+      "PaymentDate",
+      "Overdue",
+      "PDFLink",
+      "NFSeNumber",
+      "NFSeType",
+      "LineItemsJSON"
+    ]);
+    var clients = ss.getSheetByName("Clients");
+    clients.clearContents();
+    clients.appendRow([
+      "ClientID",
+      "Name",
+      "Address",
+      "ContactName",
+      "ContactPosition",
+      "ContactEmail",
+      "ContactPhone",
+      "TaxID/CNPJ",
+      "Export"
+    ]);
+    clients.appendRow([1, "Test Client", "", "", "", "test@example.com"]);
+    invoices.appendRow([
+      1,
+      1,
+      new Date(),
+      new Date(),
+      new Date(),
+      new Date(),
+      100,
+      "NO",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "[]"
+    ]);
+
+    generateInvoicePDF(1, "<table></table>", 100, 1);
+    var link = invoices.getRange(2, 11).getValue();
+    assert.ok(link, "PDF link should be set");
+  });
+}

--- a/tests/SheetsUtil.test.gs
+++ b/tests/SheetsUtil.test.gs
@@ -1,0 +1,34 @@
+// @flow
+/**
+ * QUnit tests for ensureSheets utility.
+ */
+function SheetsUtilTestSuite() {
+  QUnit.module("SheetsUtil");
+
+  QUnit.test(
+    "ensureSheets creates missing sheets and headers",
+    function (assert) {
+      var ss = SpreadsheetApp.getActive();
+      var names = [
+        "Machines",
+        "Services",
+        "BillingConfig",
+        "Clients",
+        "Invoices",
+        "Dashboards"
+      ];
+      names.forEach(function (name) {
+        var sheet = ss.getSheetByName(name);
+        if (sheet) {
+          ss.deleteSheet(sheet);
+        }
+      });
+
+      ensureSheets();
+
+      names.forEach(function (name) {
+        assert.ok(ss.getSheetByName(name), "Sheet " + name + " exists");
+      });
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add QUnit tests for `ensureSheets` and `generateInvoicePDF`
- explain how to run the tests in Apps Script

## Testing
- `npx prettier -w README.md tests/SheetsUtil.test.gs tests/Billing.test.gs`
- `npx eslint tests/SheetsUtil.test.gs tests/Billing.test.gs`

------
https://chatgpt.com/codex/tasks/task_e_688ac9c803e083298194d5dedd2a184c