### PR TITLE
Add lint workflow and configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,5 +6,13 @@ module.exports = [
       sourceType: 'script'
     },
     rules: {}
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    },
+    rules: {}
   }
 ];

--- a/package.json
+++ b/package.json
@@ -4,5 +4,14 @@
   "private": true,
   "engines": {
     "node": ">=18 <=20"
+  },
+  "scripts": {
+    "lint": "eslint \"**/*.{js,gs}\" --max-warnings 0 && stylelint \"**/*.css\" --max-warnings 0",
+    "format": "prettier --write \"**/*.{js,gs,css,md}\""
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "stylelint": "^16.2.1"
   }
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['stylelint-config-standard'],
+  rules: {},
+};


### PR DESCRIPTION
## Summary
- set up ESLint, Prettier, and Stylelint tooling
- configure lint/format npm scripts
- expand ESLint coverage to .js files
- add Stylelint config
- run lint workflow on push

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac9c9612c8329acbb6ed23315de3c