### PR TITLE
Centralize sheet names in config

### DIFF
--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -4,14 +4,17 @@ This guide describes how to set up the Invoice Automation system using Google Sh
 Ensure that Node.js **20.19.0** is installed locally. Development tools expect a Node version in the range `>=18 <=20`.
 
 ## 1. Create the Spreadsheet
+
 1. In Google Drive create a new Google Sheet named **Invoice-Automation**.
 2. Open **Extensions → Apps Script** to open the Apps Script editor.
 
 ## 2. Copy the Scripts
+
 1. In the Apps Script editor, create a file named `Code.gs` and paste the contents from `invoice_automation_blueprint.md`.
 2. Save the script project.
 
 ## 3. Authorize Triggers
+
 1. Run the `ensureSheets()` function to initialize sheets and templates.
 2. When prompted, grant the following OAuth scopes:
    - `https://www.googleapis.com/auth/spreadsheets`
@@ -23,15 +26,19 @@ Ensure that Node.js **20.19.0** is installed locally. Development tools expect a
    - `updateOverdueStatus` – Time-driven, Daily, 01:00.
 
 ## 4. Configure Script Properties
+
 1. In the Apps Script editor open **Project Settings → Script Properties**.
 2. Add the following key/value pairs:
    - `NFSE_TOKEN` – your PlugNotas API token.
    - `PIX_QR_URL` – URL of the PIX QR code image (optional).
 
 ## 5. Test Invoice Cycle
-1. Add sample data to the `Clients`, `Machines` and `BillingConfig` sheets.
+
+1. Add sample data to the sheets listed in `CONFIG.SHEETS` (`Clients`,
+   `Machines` and `BillingConfig`).
 2. Click **Run → runMonthlyBilling** in the Apps Script editor.
 3. Verify that a PDF invoice is generated in your Drive and emailed to the client.
 
 ## Screenshots
+
 Include screenshots of the Apps Script editor showing how to add triggers and a GIF of a test invoice run. Save them under the `docs/images` directory.

--- a/front-end/main.js
+++ b/front-end/main.js
@@ -4,9 +4,9 @@ type FormMeta = { id: string, name: string };
 type Invoice = { number: string, client: string };
 
 function hideAppsScriptBar(): void {
-  const style = document.createElement('style');
+  const style = document.createElement("style");
   style.textContent =
-    '.powered-by-google, .modal-dialog + div { display:none !important; }';
+    ".powered-by-google, .modal-dialog + div { display:none !important; }";
   document.head.appendChild(style);
 }
 
@@ -29,14 +29,14 @@ function fetchRecentInvoices(): Promise<Array<Invoice>> {
 }
 
 async function populateFormSelect(): Promise<void> {
-  const select = document.getElementById('service-form');
+  const select = document.getElementById("service-form");
   if (!select) {
     return;
   }
   try {
     const meta = await fetchFormMetadata();
     meta.forms.forEach((f) => {
-      const opt = document.createElement('option');
+      const opt = document.createElement("option");
       opt.value = f.id;
       opt.textContent = f.name;
       select.appendChild(opt);
@@ -47,15 +47,15 @@ async function populateFormSelect(): Promise<void> {
 }
 
 async function populateRecentInvoices(): Promise<void> {
-  const list = document.getElementById('recent-invoices');
+  const list = document.getElementById("recent-invoices");
   if (!list) {
     return;
   }
   try {
     const invoices = await fetchRecentInvoices();
     invoices.forEach((inv) => {
-      const item = document.createElement('li');
-      item.className = 'list-group-item';
+      const item = document.createElement("li");
+      item.className = "list-group-item";
       item.textContent = `${inv.number} - ${inv.client}`;
       list.appendChild(item);
     });
@@ -64,7 +64,7 @@ async function populateRecentInvoices(): Promise<void> {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   hideAppsScriptBar();
   void populateFormSelect();
   void populateRecentInvoices();

--- a/invoice_automation_blueprint.md
+++ b/invoice_automation_blueprint.md
@@ -1,11 +1,12 @@
 # **Free Cloud Invoice & Storage Management App – Complete Blueprint**
 
 > **Objective**  
-> Build a **100 % free**, cloud‑hosted system that:  
-> 1. Tracks computers sent for **storage** and **services**.  
-> 2. Automates **monthly invoicing** (PDF + NFSe for São Paulo).  
-> 3. Provides live **dashboards** (revenue, profit, turnaround).  
-> 4. Runs entirely on **Google Workspace free tier** (Sheets + Apps Script).  
+> Build a **100 % free**, cloud‑hosted system that:
+>
+> 1. Tracks computers sent for **storage** and **services**.
+> 2. Automates **monthly invoicing** (PDF + NFSe for São Paulo).
+> 3. Provides live **dashboards** (revenue, profit, turnaround).
+> 4. Runs entirely on **Google Workspace free tier** (Sheets + Apps Script).
 > 5. Can be extended with a free front‑end (optional).
 
 ---
@@ -30,87 +31,100 @@
                                    └────────────────────────┘
 ```
 
-* **Google Sheets** = single source of truth (tables & formulas).  
-* **Apps Script** = business logic + email/PDF/NFSe automation.  
-* **Google Docs** = auto‑generated invoice template → merged to PDF.  
-* **NFSe API** = PlugNotas/eNotas (free tier).  
-* **Optional** front‑end (React or HTMLService) consumes Apps Script REST.
+- **Google Sheets** = single source of truth (tables & formulas).
+- **Apps Script** = business logic + email/PDF/NFSe automation.
+- **Google Docs** = auto‑generated invoice template → merged to PDF.
+- **NFSe API** = PlugNotas/eNotas (free tier).
+- **Optional** front‑end (React or HTMLService) consumes Apps Script REST.
 
 ---
 
 ## 2  Data Model (Sheets)
 
-| Sheet | Columns | Notes |
-|-------|---------|-------|
-| **Machines** | Serial (PK) · Model · ClientID · StorageRate _(R$/month)_ · DateIn · DateOut · Status _(stored / service / returned)_ · LastBilledThrough | Serial is unique key |
-| **Services** | ServiceID _(auto)_ · Serial _(validation)_ · ClientID _(lookup)_ · ServiceDate · ServiceType _(dropdown)_ · Description · UnitPrice · QtyHours · TotalPrice _(formula)_ · Billed _(YES/NO)_ | Links to BillingConfig for prices |
-| **BillingConfig** | ServiceType _(PK)_ · UnitPrice · DefaultTax% | Maintains price list |
-| **Clients** | ClientID _(PK)_ · Name · Address · ContactName · ContactPosition · ContactEmail · ContactPhone · TaxID/CNPJ · Export _(YES/NO)_ | Export=YES triggers NFSe Externa |
-| **Invoices** | InvoiceID _(auto)_ · ClientID · PeriodStart · PeriodEnd · IssueDate _(=TODAY())_ · DueDate _(=IssueDate+15)_ · Total · Paid _(YES/NO)_ · PaymentDate · Overdue _(formula)_ · PDFLink · NFSeNumber · NFSeType · LineItemsJSON | Single invoice per client per month |
-| **Dashboards** | Auto‑generated tables & charts | No manual edits |
+| Sheet             | Columns                                                                                                                                                                                                                      | Notes                               |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Machines**      | Serial (PK) · Model · ClientID · StorageRate _(R$/month)_ · DateIn · DateOut · Status _(stored / service / returned)_ · LastBilledThrough                                                                                    | Serial is unique key                |
+| **Services**      | ServiceID _(auto)_ · Serial _(validation)_ · ClientID _(lookup)_ · ServiceDate · ServiceType _(dropdown)_ · Description · UnitPrice · QtyHours · TotalPrice _(formula)_ · Billed _(YES/NO)_                                  | Links to BillingConfig for prices   |
+| **BillingConfig** | ServiceType _(PK)_ · UnitPrice · DefaultTax%                                                                                                                                                                                 | Maintains price list                |
+| **Clients**       | ClientID _(PK)_ · Name · Address · ContactName · ContactPosition · ContactEmail · ContactPhone · TaxID/CNPJ · Export _(YES/NO)_                                                                                              | Export=YES triggers NFSe Externa    |
+| **Invoices**      | InvoiceID _(auto)_ · ClientID · PeriodStart · PeriodEnd · IssueDate _(=TODAY())_ · DueDate _(=IssueDate+15)_ · Total · Paid _(YES/NO)_ · PaymentDate · Overdue _(formula)_ · PDFLink · NFSeNumber · NFSeType · LineItemsJSON | Single invoice per client per month |
+| **Dashboards**    | Auto‑generated tables & charts                                                                                                                                                                                               | No manual edits                     |
 
 ---
 
 ## 3  Apps Script Modules
 
 ### 3.1  Config (`CONFIG`)
+
 ```js
 const CONFIG = {
-  COMPANY_NAME: 'Devops Consultoria e Desenvolvimento de Softwares LTDA',
-  COMPANY_ADDRESS: 'Av. Paulista, 1636, 15º Andar, CJ 04, São Paulo – SP, 01310‑200',
-  CNPJ: '54566671000143',
-  IM: '13006525',
-  PDF_FOLDER_ID: '1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh',
-  COLOR_BLUE: '#003B70'
+  COMPANY_NAME: "Devops Consultoria e Desenvolvimento de Softwares LTDA",
+  COMPANY_ADDRESS:
+    "Av. Paulista, 1636, 15º Andar, CJ 04, São Paulo – SP, 01310‑200",
+  CNPJ: "54566671000143",
+  IM: "13006525",
+  PDF_FOLDER_ID: "1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh",
+  COLOR_BLUE: "#003B70",
+  SHEETS: {
+    MACHINES: "Machines",
+    SERVICES: "Services",
+    BILLING_CONFIG: "BillingConfig",
+    CLIENTS: "Clients",
+    INVOICES: "Invoices",
+    DASHBOARDS: "Dashboards"
+  }
 };
 
 // Fetch sensitive tokens from Script Properties
 var SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
 
 function getNFSeToken() {
-  return SCRIPT_PROPERTIES.getProperty('NFSE_TOKEN');
+  return SCRIPT_PROPERTIES.getProperty("NFSE_TOKEN");
 }
 
 function getPixQrUrl() {
-  return SCRIPT_PROPERTIES.getProperty('PIX_QR_URL');
+  return SCRIPT_PROPERTIES.getProperty("PIX_QR_URL");
 }
 ```
 
 ### 3.2  Setup Functions
-| Function | Purpose |
-|----------|---------|
-| `ensureSheets()` | Creates all sheets, headers, formulas, data‑validation. |
+
+| Function              | Purpose                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `ensureSheets()`      | Creates all sheets, headers, formulas, data‑validation.                                                  |
 | `ensureTemplateDoc()` | Generates Google Docs invoice template (white/blue) on first run and stores Doc ID in Script Properties. |
-| `refreshDashboards()` | Inserts `QUERY()` formulas + ChartBuilder graphs (auto‑recalc). |
+| `refreshDashboards()` | Inserts `QUERY()` formulas + ChartBuilder graphs (auto‑recalc).                                          |
 
 ### 3.3  Operational Triggers
-| Function | Trigger Type | Schedule |
-|----------|--------------|----------|
-| `addService(e)` | **onEdit** (Services) | Event‑based |
-| `runMonthlyBilling()` | Time‑driven | 1st day each month, 02:00 |
-| `updateOverdueStatus()` | Time‑driven | Daily, 01:00 |
-| `refreshDashboards()` | Manual or weekly cron | Mondays, 03:00 |
+
+| Function                | Trigger Type          | Schedule                  |
+| ----------------------- | --------------------- | ------------------------- |
+| `addService(e)`         | **onEdit** (Services) | Event‑based               |
+| `runMonthlyBilling()`   | Time‑driven           | 1st day each month, 02:00 |
+| `updateOverdueStatus()` | Time‑driven           | Daily, 01:00              |
+| `refreshDashboards()`   | Manual or weekly cron | Mondays, 03:00            |
 
 ### 3.4  Core Logic
-* **addService** – auto‑populate `UnitPrice` & `TotalPrice`, mark `Billed=NO`.
-* **runMonthlyBilling**  
-  1. Compute storage (pro‑rata) for all Serial with Status=`stored`.  
-  2. Pull un‑billed services.  
-  3. Aggregate by Client → create `Invoices` row; build merge object.  
-  4. Call `generateInvoicePDF()` → save PDF to Drive, email client.  
+
+- **addService** – auto‑populate `UnitPrice` & `TotalPrice`, mark `Billed=NO`.
+- **runMonthlyBilling**
+  1. Compute storage (pro‑rata) for all Serial with Status=`stored`.
+  2. Pull un‑billed services.
+  3. Aggregate by Client → create `Invoices` row; build merge object.
+  4. Call `generateInvoicePDF()` → save PDF to Drive, email client.
   5. Mark services `Billed=YES`, update `LastBilledThrough`.
-* **issueNFSe** – manual menu; posts to PlugNotas with correct tags.
+- **issueNFSe** – manual menu; posts to PlugNotas with correct tags.
 
 ---
 
 ## 4  Invoice Template Merge Tags
 
-| Tag | Source |
-|-----|--------|
-| `{{CompanyName}}`, `{{CNPJ}}`, `{{IM}}` | `CONFIG` |
-| `{{InvoiceID}}`, `{{IssueDate}}`, `{{DueDate}}`, `{{Total}}` | `Invoices` |
-| `{{ClientName}}`, `{{ContactName}}`, `{{ContactEmail}}` | `Clients` |
-| `{{LineItemsTable}}` | Generated HTML table inside `generateInvoicePDF()` |
+| Tag                                                          | Source                                             |
+| ------------------------------------------------------------ | -------------------------------------------------- |
+| `{{CompanyName}}`, `{{CNPJ}}`, `{{IM}}`                      | `CONFIG`                                           |
+| `{{InvoiceID}}`, `{{IssueDate}}`, `{{DueDate}}`, `{{Total}}` | `Invoices`                                         |
+| `{{ClientName}}`, `{{ContactName}}`, `{{ContactEmail}}`      | `Clients`                                          |
+| `{{LineItemsTable}}`                                         | Generated HTML table inside `generateInvoicePDF()` |
 
 Template created with Apps Script:
 
@@ -123,13 +137,13 @@ doc.appendParagraph(CONFIG.COMPANY_NAME).setBold().setForegroundColor(CONFIG.COL
 
 ## 5  Dashboard Metrics (live)
 
-| KPI | Query Formula |
-|-----|---------------|
-| **Revenue per Month** | `=QUERY(Invoices!A:K,"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'",1)` |
-| **Profit per Month** | Revenue – Costs (`SUMPRODUCT` from Services & Storage) |
-| **Avg Storage Days** | `=AVERAGE(IF(Machines!Status="returned", Machines!DateOut - Machines!DateIn))` |
-| **Services / Machine** | `=QUERY(Services!A:G,"select Serial, count(ServiceID) group by Serial",1)` |
-| **Receivables Aging** | `=ARRAYFORMULA(IF(Invoices!Paid="NO", TODAY()-Invoices!DueDate, ))` |
+| KPI                    | Query Formula                                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Revenue per Month**  | `=QUERY(Invoices!A:K,"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'",1)` |
+| **Profit per Month**   | Revenue – Costs (`SUMPRODUCT` from Services & Storage)                                                                                   |
+| **Avg Storage Days**   | `=AVERAGE(IF(Machines!Status="returned", Machines!DateOut - Machines!DateIn))`                                                           |
+| **Services / Machine** | `=QUERY(Services!A:G,"select Serial, count(ServiceID) group by Serial",1)`                                                               |
+| **Receivables Aging**  | `=ARRAYFORMULA(IF(Invoices!Paid="NO", TODAY()-Invoices!DueDate, ))`                                                                      |
 
 `refreshDashboards()` writes these into helper ranges, then builds Column / Line / Pie charts with `ChartBuilder`. Since formulas live in the sheet, charts update instantly as data changes—script only runs once at setup.
 
@@ -137,34 +151,36 @@ doc.appendParagraph(CONFIG.COMPANY_NAME).setBold().setForegroundColor(CONFIG.COL
 
 ## 6  Zero‑Cost Front‑End (optional)
 
-### Option A – Apps Script `HtmlService`  
-* Serve `index.html`, use `google.script.run`.  
-* Bootstrap 5, runs within Sheets container (no hosting costs).
+### Option A – Apps Script `HtmlService`
 
-### Option B – Static SPA  
-* Build React/Vite → deploy to **GitHub Pages** (free).  
-* Apps Script Web App provides JSON endpoints `/machines`, `/services`, `/invoices`.
+- Serve `index.html`, use `google.script.run`.
+- Bootstrap 5, runs within Sheets container (no hosting costs).
+
+### Option B – Static SPA
+
+- Build React/Vite → deploy to **GitHub Pages** (free).
+- Apps Script Web App provides JSON endpoints `/machines`, `/services`, `/invoices`.
 
 ---
 
 ## 7  Deployment Checklist
 
-1. Create Google Sheet “Invoice‑Automation”.  
-2. Open **Extensions → Apps Script**, paste **Code.gs** (includes all modules).  
-3. Run **ensureSheets()** → authorize scope.  
-4. Run **Setup / Ensure Sheets** from custom menu (creates template + dashboards).  
-5. Add Triggers (monthly, daily).  
-6. Add initial Clients, Machines, BillingConfig rows.  
+1. Create Google Sheet “Invoice‑Automation”.
+2. Open **Extensions → Apps Script**, paste **Code.gs** (includes all modules).
+3. Run **ensureSheets()** → authorize scope.
+4. Run **Setup / Ensure Sheets** from custom menu (creates template + dashboards).
+5. Add Triggers (monthly, daily).
+6. Add initial Clients, Machines, BillingConfig rows.
 7. Confirm an invoice cycles successfully via **Run Monthly Billing** test.
 
 ---
 
 ## 8  Future Roadmap
 
-* **Payment QR Code (PIX)** in PDF.  
-* **Webhook** from payment gateway to auto‑flag Paid.  
-* Multi‑tenant mode: one workbook per client in Shared Drive + master dashboard via Data Studio (free).  
-* Mobile PWA front‑end (React + Workbox) hosted on GitHub Pages.
+- **Payment QR Code (PIX)** in PDF.
+- **Webhook** from payment gateway to auto‑flag Paid.
+- Multi‑tenant mode: one workbook per client in Shared Drive + master dashboard via Data Studio (free).
+- Mobile PWA front‑end (React + Workbox) hosted on GitHub Pages.
 
 ---
 
@@ -184,4 +200,4 @@ doc.appendParagraph(CONFIG.COMPANY_NAME).setBold().setForegroundColor(CONFIG.COL
 ---
 
 _End of Blueprint_  
-Save this content as **invoice_automation_blueprint.md** and upload to your AI builder._
+Save this content as **invoice_automation_blueprint.md** and upload to your AI builder.\_

--- a/src/Billing.gs
+++ b/src/Billing.gs
@@ -4,10 +4,10 @@
  */
 function runMonthlyBilling() {
   var ss = SpreadsheetApp.getActive();
-  var machinesSheet = ss.getSheetByName("Machines");
-  var servicesSheet = ss.getSheetByName("Services");
-  var invoicesSheet = ss.getSheetByName("Invoices");
-  var clientsSheet = ss.getSheetByName("Clients");
+  var machinesSheet = ss.getSheetByName(CONFIG.SHEETS.MACHINES);
+  var servicesSheet = ss.getSheetByName(CONFIG.SHEETS.SERVICES);
+  var invoicesSheet = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
+  var clientsSheet = ss.getSheetByName(CONFIG.SHEETS.CLIENTS);
 
   if (!machinesSheet || !servicesSheet || !invoicesSheet || !clientsSheet) {
     SpreadsheetApp.getUi().alert("Missing sheets. Run ensureSheets first.");
@@ -102,8 +102,8 @@ function runMonthlyBilling() {
  */
 function generateInvoicePDF(invoiceId, itemsTable, total, clientId) {
   var ss = SpreadsheetApp.getActive();
-  var clientsSheet = ss.getSheetByName("Clients");
-  var invoicesSheet = ss.getSheetByName("Invoices");
+  var clientsSheet = ss.getSheetByName(CONFIG.SHEETS.CLIENTS);
+  var invoicesSheet = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
   var data = clientsSheet.getDataRange().getValues();
   var clientRow;
   for (var i = 1; i < data.length; i++) {

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -116,11 +116,11 @@ function doGet(e) {
   var path = e && e.pathInfo ? String(e.pathInfo).replace(/^\//, "") : "";
   switch (path) {
     case "machines":
-      return sheetToJson_("Machines");
+      return sheetToJson_(CONFIG.SHEETS.MACHINES);
     case "services":
-      return sheetToJson_("Services");
+      return sheetToJson_(CONFIG.SHEETS.SERVICES);
     case "invoices":
-      return sheetToJson_("Invoices");
+      return sheetToJson_(CONFIG.SHEETS.INVOICES);
     default:
       return ContentService.createTextOutput("{}").setMimeType(
         ContentService.MimeType.JSON

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -10,7 +10,15 @@ var CONFIG = {
   CNPJ: "54566671000143",
   IM: "13006525",
   PDF_FOLDER_ID: "1roHYH7e5g0CcnLsKa_QWdjnJ0hBmo6Fh",
-  COLOR_BLUE: "#003B70"
+  COLOR_BLUE: "#003B70",
+  SHEETS: {
+    MACHINES: "Machines",
+    SERVICES: "Services",
+    BILLING_CONFIG: "BillingConfig",
+    CLIENTS: "Clients",
+    INVOICES: "Invoices",
+    DASHBOARDS: "Dashboards"
+  }
 };
 
 // Lazily load sensitive values from Script Properties

--- a/src/NFSe.gs
+++ b/src/NFSe.gs
@@ -9,7 +9,7 @@ function issueNFSe(invoiceId) {
     return;
   }
   var ss = SpreadsheetApp.getActive();
-  var invoices = ss.getSheetByName("Invoices");
+  var invoices = ss.getSheetByName(CONFIG.SHEETS.INVOICES);
   if (!invoices) {
     return;
   }

--- a/src/ServiceHooks.gs
+++ b/src/ServiceHooks.gs
@@ -4,7 +4,11 @@
  * @param {GoogleAppsScript.Events.SheetsOnEdit} e Edit event object.
  */
 function addService(e) {
-  if (!e || !e.range || e.range.getSheet().getName() !== "Services") {
+  if (
+    !e ||
+    !e.range ||
+    e.range.getSheet().getName() !== CONFIG.SHEETS.SERVICES
+  ) {
     return;
   }
   var sheet = e.range.getSheet();
@@ -13,7 +17,9 @@ function addService(e) {
   if (!serviceType) {
     return;
   }
-  var configSheet = SpreadsheetApp.getActive().getSheetByName("BillingConfig");
+  var configSheet = SpreadsheetApp.getActive().getSheetByName(
+    CONFIG.SHEETS.BILLING_CONFIG
+  );
   if (!configSheet) {
     return;
   }

--- a/src/SheetsUtil.gs
+++ b/src/SheetsUtil.gs
@@ -11,59 +11,63 @@
  */
 function ensureSheets() {
   var ss = SpreadsheetApp.getActive();
-  var sheetSpecs = {
-    Machines: [
-      "Serial",
-      "Model",
-      "ClientID",
-      "StorageRate",
-      "DateIn",
-      "DateOut",
-      "Status",
-      "LastBilledThrough"
-    ],
-    Services: [
-      "ServiceID",
-      "Serial",
-      "ClientID",
-      "ServiceDate",
-      "ServiceType",
-      "Description",
-      "UnitPrice",
-      "QtyHours",
-      "TotalPrice",
-      "Billed"
-    ],
-    BillingConfig: ["ServiceType", "UnitPrice", "DefaultTax%"],
-    Clients: [
-      "ClientID",
-      "Name",
-      "Address",
-      "ContactName",
-      "ContactPosition",
-      "ContactEmail",
-      "ContactPhone",
-      "TaxID/CNPJ",
-      "Export"
-    ],
-    Invoices: [
-      "InvoiceID",
-      "ClientID",
-      "PeriodStart",
-      "PeriodEnd",
-      "IssueDate",
-      "DueDate",
-      "Total",
-      "Paid",
-      "PaymentDate",
-      "Overdue",
-      "PDFLink",
-      "NFSeNumber",
-      "NFSeType",
-      "LineItemsJSON"
-    ],
-    Dashboards: []
-  };
+  var sheetSpecs = {};
+  sheetSpecs[CONFIG.SHEETS.MACHINES] = [
+    "Serial",
+    "Model",
+    "ClientID",
+    "StorageRate",
+    "DateIn",
+    "DateOut",
+    "Status",
+    "LastBilledThrough"
+  ];
+  sheetSpecs[CONFIG.SHEETS.SERVICES] = [
+    "ServiceID",
+    "Serial",
+    "ClientID",
+    "ServiceDate",
+    "ServiceType",
+    "Description",
+    "UnitPrice",
+    "QtyHours",
+    "TotalPrice",
+    "Billed"
+  ];
+  sheetSpecs[CONFIG.SHEETS.BILLING_CONFIG] = [
+    "ServiceType",
+    "UnitPrice",
+    "DefaultTax%"
+  ];
+  sheetSpecs[CONFIG.SHEETS.CLIENTS] = [
+    "ClientID",
+    "Name",
+    "Address",
+    "ContactName",
+    "ContactPosition",
+    "ContactEmail",
+    "ContactPhone",
+    "TaxID/CNPJ",
+    "Export"
+  ];
+  sheetSpecs[CONFIG.SHEETS.INVOICES] = [
+    "InvoiceID",
+    "ClientID",
+    "PeriodStart",
+    "PeriodEnd",
+    "IssueDate",
+    "DueDate",
+    "Total",
+    "Paid",
+    "PaymentDate",
+    "Overdue",
+    "PDFLink",
+    "NFSeNumber",
+    "NFSeType",
+    "LineItemsJSON"
+  ];
+  sheetSpecs[CONFIG.SHEETS.DASHBOARDS] = [];
+
   Object.keys(sheetSpecs).forEach(function (name) {
     var sheet = ss.getSheetByName(name);
     if (!sheet) {
@@ -110,7 +114,7 @@ function ensureTemplateDoc() {
  */
 function refreshDashboards() {
   var ss = SpreadsheetApp.getActive();
-  var sheet = ss.getSheetByName("Dashboards");
+  var sheet = ss.getSheetByName(CONFIG.SHEETS.DASHBOARDS);
   if (!sheet) {
     return;
   }
@@ -119,12 +123,16 @@ function refreshDashboards() {
   sheet
     .getRange("A1")
     .setFormula(
-      "=QUERY(Invoices!A:K,\"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'\",1)"
+      "=QUERY(" +
+        CONFIG.SHEETS.INVOICES +
+        "!A:K,\"select year(IssueDate), month(IssueDate), sum(Total) where Paid='YES' group by 1,2 label sum(Total) 'Revenue'\",1)"
     );
   sheet
     .getRange("E1")
     .setFormula(
-      "=QUERY(Services!A:J,\"select year(ServiceDate), month(ServiceDate), sum(TotalPrice) where Billed='YES' group by 1,2 label sum(TotalPrice) 'ServiceCosts'\",1)"
+      "=QUERY(" +
+        CONFIG.SHEETS.SERVICES +
+        "!A:J,\"select year(ServiceDate), month(ServiceDate), sum(TotalPrice) where Billed='YES' group by 1,2 label sum(TotalPrice) 'ServiceCosts'\",1)"
     );
   var chart = sheet
     .newChart()


### PR DESCRIPTION
## Summary
- collect sheet names in `CONFIG.SHEETS`
- reference sheet constants throughout the Apps Script code
- document the new constants in the blueprint and setup guide

## Testing
- `npm run lint:js` *(fails: Invalid option '--ext')*
- `npm run lint:styles`
- `npx prettier -w src/*.gs front-end/*.js docs/*.md README.md invoice_automation_blueprint.md`
- `npx eslint front-end/*.js src/*.gs` *(fails: Parsing error)*
- `flake8 --exclude=node_modules`
- `pydocstyle --match-dir='^(?!node_modules).*'`
- `mypy` *(fails: Missing target module)*

------
https://chatgpt.com/codex/tasks/task_e_688acb2c1fa08329ab597d9a8999ab81