### PR TITLE
Add service API hooks

### DIFF
--- a/front-end/index.html
+++ b/front-end/index.html
@@ -76,7 +76,7 @@
       </div>
     </nav>
 
-    <main class="container tab-content" style="padding-top: 4rem;">
+    <main class="container tab-content" style="padding-top: 4rem">
       <section
         class="tab-pane fade show active"
         id="dashboard"
@@ -94,7 +94,8 @@
         aria-labelledby="service-tab"
       >
         <h1 class="mb-3">New Service</h1>
-        <form id="service-form" class="row g-3"></form>
+        <form id="service-form" class="row g-3 mb-3"></form>
+        <button id="send-btn" class="btn btn-primary">Submit Service</button>
       </section>
 
       <section
@@ -104,11 +105,16 @@
         aria-labelledby="invoices-tab"
       >
         <h1 class="mb-3">Invoices</h1>
+        <button id="load-btn" class="btn btn-secondary mb-3">Load JSON</button>
         <pre id="output" class="bg-body-tertiary p-3"></pre>
       </section>
     </main>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-FE1vzzUMsQ9iDUn30T+yecnP+X7iYsJhBKt3vnDnNQfXlBx/OVCkXbkqXA67R9Oj" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-FE1vzzUMsQ9iDUn30T+yecnP+X7iYsJhBKt3vnDnNQfXlBx/OVCkXbkqXA67R9Oj"
+      crossorigin="anonymous"
+    ></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/front-end/main.js
+++ b/front-end/main.js
@@ -3,10 +3,37 @@
 type FormMeta = { id: string, name: string };
 type Invoice = { number: string, client: string };
 
+function sendData(): void {
+  const form = document.getElementById("service-form");
+  if (!(form instanceof HTMLFormElement)) {
+    return;
+  }
+  const record = Object.fromEntries(new FormData(form).entries());
+  google.script.run
+    .withSuccessHandler(() => {
+      form.reset();
+      loadData();
+    })
+    .withFailureHandler((err) => console.error(err))
+    .addServiceRecord(record);
+}
+
+function loadData(): void {
+  google.script.run
+    .withSuccessHandler((data) => {
+      const out = document.getElementById("output");
+      if (out) {
+        out.textContent = JSON.stringify(data, null, 2);
+      }
+    })
+    .withFailureHandler((err) => console.error(err))
+    .getInvoicesJSON();
+}
+
 function hideAppsScriptBar(): void {
-  const style = document.createElement('style');
+  const style = document.createElement("style");
   style.textContent =
-    '.powered-by-google, .modal-dialog + div { display:none !important; }';
+    ".powered-by-google, .modal-dialog + div { display:none !important; }";
   document.head.appendChild(style);
 }
 
@@ -29,14 +56,14 @@ function fetchRecentInvoices(): Promise<Array<Invoice>> {
 }
 
 async function populateFormSelect(): Promise<void> {
-  const select = document.getElementById('service-form');
+  const select = document.getElementById("service-form");
   if (!select) {
     return;
   }
   try {
     const meta = await fetchFormMetadata();
     meta.forms.forEach((f) => {
-      const opt = document.createElement('option');
+      const opt = document.createElement("option");
       opt.value = f.id;
       opt.textContent = f.name;
       select.appendChild(opt);
@@ -47,15 +74,15 @@ async function populateFormSelect(): Promise<void> {
 }
 
 async function populateRecentInvoices(): Promise<void> {
-  const list = document.getElementById('recent-invoices');
+  const list = document.getElementById("recent-invoices");
   if (!list) {
     return;
   }
   try {
     const invoices = await fetchRecentInvoices();
     invoices.forEach((inv) => {
-      const item = document.createElement('li');
-      item.className = 'list-group-item';
+      const item = document.createElement("li");
+      item.className = "list-group-item";
       item.textContent = `${inv.number} - ${inv.client}`;
       list.appendChild(item);
     });
@@ -64,8 +91,12 @@ async function populateRecentInvoices(): Promise<void> {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   hideAppsScriptBar();
   void populateFormSelect();
   void populateRecentInvoices();
+  const sendBtn = document.getElementById("send-btn");
+  if (sendBtn) sendBtn.addEventListener("click", sendData);
+  const loadBtn = document.getElementById("load-btn");
+  if (loadBtn) loadBtn.addEventListener("click", loadData);
 });

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -127,3 +127,38 @@ function doGet(e) {
       );
   }
 }
+
+/**
+ * Returns invoices data as JSON for the web front-end.
+ * @return {GoogleAppsScript.Content.TextOutput} JSON output.
+ */
+function getInvoicesJSON() {
+  return sheetToJson_("Invoices");
+}
+
+/**
+ * Returns metadata for available service forms.
+ * @return {{forms: Array<{id: string, name: string}>}}
+ */
+function getFormMetadata() {
+  return { forms: [{ id: "service", name: "Service Entry" }] };
+}
+
+/**
+ * Lists the five most recent invoices for the dashboard.
+ * @return {Array<{number: string, client: string}>}
+ */
+function listRecentInvoices() {
+  var sheet = SpreadsheetApp.getActive().getSheetByName("Invoices");
+  if (!sheet) {
+    return [];
+  }
+  var data = sheet.getDataRange().getValues();
+  if (data.length <= 1) {
+    return [];
+  }
+  data.shift();
+  return data.slice(-5).map(function (row) {
+    return { number: String(row[0]), client: row[1] };
+  });
+}

--- a/src/ServiceHooks.gs
+++ b/src/ServiceHooks.gs
@@ -28,3 +28,42 @@ function addService(e) {
     }
   }
 }
+
+/**
+ * Adds a new service record from the web front-end.
+ * @param {Object} svc Service data from the form.
+ */
+function addServiceRecord(svc) {
+  var ss = SpreadsheetApp.getActive();
+  var sheet = ss.getSheetByName("Services");
+  if (!sheet) {
+    return;
+  }
+  var row = sheet.getLastRow() + 1;
+  sheet.appendRow([
+    svc.ServiceID || "",
+    svc.Serial || "",
+    svc.ClientID || "",
+    svc.ServiceDate ? new Date(svc.ServiceDate) : new Date(),
+    svc.ServiceType || "",
+    svc.Description || "",
+    "",
+    svc.QtyHours || 1,
+    "",
+    ""
+  ]);
+  var configSheet = ss.getSheetByName("BillingConfig");
+  if (!configSheet) {
+    return;
+  }
+  var configs = configSheet.getDataRange().getValues();
+  for (var i = 1; i < configs.length; i++) {
+    if (configs[i][0] === svc.ServiceType) {
+      sheet.getRange(row, 7).setValue(configs[i][1]);
+      var qty = svc.QtyHours || 1;
+      sheet.getRange(row, 9).setValue(qty * configs[i][1]);
+      sheet.getRange(row, 10).setValue("NO");
+      break;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `addServiceRecord` and `getInvoicesJSON` backend methods
- expose simple form metadata and recent invoice list
- rewrite `sendData` and `loadData` on client to call new backend methods
- hook up UI buttons for submitting services and fetching invoices

## Testing
- `npm run lint:js` *(fails: Invalid option `--ext`)*
- `npm run lint:styles`
- `npx prettier -w front-end/main.js front-end/index.html src/Code.gs src/ServiceHooks.gs`

------
https://chatgpt.com/codex/tasks/task_e_688acc8c886c8329a341206e5768a0a1