### PR TITLE
Add JSDoc comments and lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 src/package-lock.json
+node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,13 @@ module.exports = [
       ecmaVersion: 5,
       sourceType: "script"
     },
-    rules: {}
+    plugins: {
+      jsdoc: require("eslint-plugin-jsdoc")
+    },
+    rules: {
+      "jsdoc/require-jsdoc": "error",
+      "jsdoc/check-types": "error"
+    }
   },
   {
     files: ["front-end/**/*.js"],
@@ -21,11 +27,14 @@ module.exports = [
       }
     },
     plugins: {
-      flowtype: require("eslint-plugin-flowtype")
+      flowtype: require("eslint-plugin-flowtype"),
+      jsdoc: require("eslint-plugin-jsdoc")
     },
     rules: {
       "flowtype/define-flow-type": 1,
-      "flowtype/use-flow-type": 1
+      "flowtype/use-flow-type": 1,
+      "jsdoc/require-jsdoc": "error",
+      "jsdoc/check-types": "error"
     }
   }
 ];

--- a/front-end/main.js
+++ b/front-end/main.js
@@ -3,6 +3,11 @@
 type FormMeta = { id: string, name: string };
 type Invoice = { number: string, client: string };
 
+/**
+ * Hides the banner injected by the Apps Script iframe.
+ *
+ * Side effects: appends a style element to the document head.
+ */
 function hideAppsScriptBar(): void {
   const style = document.createElement("style");
   style.textContent =
@@ -10,6 +15,14 @@ function hideAppsScriptBar(): void {
   document.head.appendChild(style);
 }
 
+/**
+ * Retrieves the metadata for available service forms from Apps Script.
+ *
+ * Side effects: performs an RPC to the server.
+ *
+ * @return {Promise<{ forms: Array<FormMeta> }>} Promise resolving to form
+ *     metadata.
+ */
 function fetchFormMetadata(): Promise<{ forms: Array<FormMeta> }> {
   return new Promise((resolve, reject) => {
     google.script.run
@@ -19,6 +32,13 @@ function fetchFormMetadata(): Promise<{ forms: Array<FormMeta> }> {
   });
 }
 
+/**
+ * Fetches the list of recently created invoices.
+ *
+ * Side effects: performs an RPC to the server.
+ *
+ * @return {Promise<Array<Invoice>>} Promise resolving to invoices.
+ */
 function fetchRecentInvoices(): Promise<Array<Invoice>> {
   return new Promise((resolve, reject) => {
     google.script.run
@@ -28,6 +48,13 @@ function fetchRecentInvoices(): Promise<Array<Invoice>> {
   });
 }
 
+/**
+ * Populates the service form selector with options from the server.
+ *
+ * Side effects: modifies the DOM by adding option elements.
+ *
+ * @return {Promise<void>}
+ */
 async function populateFormSelect(): Promise<void> {
   const select = document.getElementById("service-form");
   if (!select) {
@@ -46,6 +73,13 @@ async function populateFormSelect(): Promise<void> {
   }
 }
 
+/**
+ * Populates the recent invoices list in the UI.
+ *
+ * Side effects: updates DOM elements with invoice data.
+ *
+ * @return {Promise<void>}
+ */
 async function populateRecentInvoices(): Promise<void> {
   const list = document.getElementById("recent-invoices");
   if (!list) {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,15 @@
     "test": "jest"
   },
   "devDependencies": {
-    "eslint": "^8.56.0",
-    "eslint-plugin-flowtype": "^8.0.3",
-    "prettier": "^3.2.5",
-    "stylelint": "^15.10.2",
-    "stylelint-config-standard": "^33.0.0",
-    "jest": "^29.7.0",
     "@babel/core": "^7.24.0",
     "@babel/eslint-parser": "^7.24.0",
-    "@babel/plugin-syntax-flow": "^7.23.3"
+    "@babel/plugin-syntax-flow": "^7.23.3",
+    "eslint": "^8.56.0",
+    "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-jsdoc": "^52.0.1",
+    "jest": "^29.7.0",
+    "prettier": "^3.2.5",
+    "stylelint": "^15.10.2",
+    "stylelint-config-standard": "^33.0.0"
   }
 }

--- a/src/Billing.gs
+++ b/src/Billing.gs
@@ -1,6 +1,11 @@
 // @flow
 /**
- * Aggregates unbilled items and generates monthly invoices.
+ * Aggregates unbilled items, creates invoices and emails PDF copies.
+ *
+ * Side effects: reads and writes spreadsheet data, generates PDF files and
+ * sends emails to clients.
+ *
+ * @return {void}
  */
 function runMonthlyBilling() {
   var ss = SpreadsheetApp.getActive();
@@ -94,11 +99,16 @@ function runMonthlyBilling() {
 }
 
 /**
- * Generates PDF for invoice and emails the client.
+ * Generates a PDF invoice document and emails it to the client.
+ *
+ * Side effects: creates files in Drive and sends an email with the PDF
+ * attachment.
+ *
  * @param {number} invoiceId Invoice ID.
  * @param {string} itemsTable HTML table with line items.
  * @param {number} total Total invoice value.
  * @param {string} clientId Client identifier.
+ * @return {void}
  */
 function generateInvoicePDF(invoiceId, itemsTable, total, clientId) {
   var ss = SpreadsheetApp.getActive();

--- a/src/Code.gs
+++ b/src/Code.gs
@@ -1,6 +1,10 @@
 // @flow
 /**
- * App entry point: builds custom menus and installs triggers.
+ * App entry point that builds menus and registers triggers.
+ *
+ * Side effects: modifies the UI menu and may create script triggers.
+ *
+ * @return {void}
  */
 function onOpen() {
   SpreadsheetApp.getUi()
@@ -18,7 +22,11 @@ function onOpen() {
 }
 
 /**
- * Registers time-driven triggers for monthly billing and overdue updates.
+ * Registers time-driven triggers for monthly billing and dashboard refresh.
+ *
+ * Side effects: creates new script triggers in the current project.
+ *
+ * @return {void}
  */
 function createTriggers() {
   ScriptApp.newTrigger("runMonthlyBilling")
@@ -35,6 +43,10 @@ function createTriggers() {
 
 /**
  * Ensures required triggers exist before running automation.
+ *
+ * Side effects: creates or deletes script triggers.
+ *
+ * @return {void}
  */
 function ensureTriggers() {
   var triggers = ScriptApp.getProjectTriggers();
@@ -77,6 +89,8 @@ function ensureTriggers() {
  * @param {string} name Sheet name.
  * @return {GoogleAppsScript.Content.TextOutput} JSON output.
  * @private
+ *
+ * Side effects: none.
  */
 function sheetToJson_(name) {
   var ss = SpreadsheetApp.getActive();
@@ -109,6 +123,8 @@ function sheetToJson_(name) {
  * Main GET handler returning JSON for project endpoints.
  * @param {GoogleAppsScript.Events.DoGet} e Event object.
  * @return {GoogleAppsScript.Content.TextOutput} JSON output.
+ *
+ * Side effects: none.
  */
 function doGet(e) {
   var path = e && e.pathInfo ? String(e.pathInfo).replace(/^\//, "") : "";

--- a/src/Config.gs
+++ b/src/Config.gs
@@ -19,6 +19,8 @@ var SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
 /**
  * Returns the NFSe API token stored in Script Properties.
  * @return {string?} token value or null if not set
+ *
+ * Side effects: none.
  */
 function getNFSeToken() {
   return SCRIPT_PROPERTIES.getProperty("NFSE_TOKEN");
@@ -27,6 +29,8 @@ function getNFSeToken() {
 /**
  * Returns the PIX QR code URL stored in Script Properties.
  * @return {string?} QR code image URL or null if not set
+ *
+ * Side effects: none.
  */
 function getPixQrUrl() {
   return SCRIPT_PROPERTIES.getProperty("PIX_QR_URL");

--- a/src/NFSe.gs
+++ b/src/NFSe.gs
@@ -2,6 +2,10 @@
 /**
  * Issues an NFSe for the given invoice.
  * @param {number} invoiceId Invoice ID to issue NFSe for.
+ *
+ * Side effects: sends an HTTP request and updates the Invoices sheet.
+ *
+ * @return {void}
  */
 function issueNFSe(invoiceId) {
   if (!invoiceId) {

--- a/src/ServiceHooks.gs
+++ b/src/ServiceHooks.gs
@@ -2,6 +2,9 @@
 /**
  * Sheet onEdit hook for Services sheet.
  * @param {GoogleAppsScript.Events.SheetsOnEdit} e Edit event object.
+ *
+ * Side effects: updates row values in the Services sheet based on the
+ * configuration table.
  */
 function addService(e) {
   if (!e || !e.range || e.range.getSheet().getName() !== "Services") {

--- a/src/SheetsUtil.gs
+++ b/src/SheetsUtil.gs
@@ -4,10 +4,14 @@
  * @namespace SheetsUtil
  */
 
-/** @typedef {Object} SheetSpec */
+/** @typedef {object} SheetSpec */
 
 /**
  * Ensures all required sheets exist and have the correct headers.
+ *
+ * Side effects: creates new sheets and headers when missing.
+ *
+ * @return {void}
  */
 function ensureSheets() {
   var ss = SpreadsheetApp.getActive();
@@ -78,6 +82,10 @@ function ensureSheets() {
 /**
  * Creates the invoice template document if not already created.
  * Stores the Doc ID in script properties under 'TEMPLATE_DOC_ID'.
+ *
+ * Side effects: creates a Google Doc and updates script properties.
+ *
+ * @return {string} Document ID of the template.
  */
 function ensureTemplateDoc() {
   var props = PropertiesService.getScriptProperties();
@@ -107,6 +115,10 @@ function ensureTemplateDoc() {
 
 /**
  * Refreshes dashboard formulas and charts.
+ *
+ * Side effects: clears and populates the Dashboards sheet and its charts.
+ *
+ * @return {void}
  */
 function refreshDashboards() {
   var ss = SpreadsheetApp.getActive();


### PR DESCRIPTION
## Summary
- add `node_modules/` to gitignore
- enforce JSDoc via eslint config
- document public Apps Script and front-end functions

## Testing
- `npm run lint:js`
- `npm run lint:styles`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688acdbac904832982769e14a6aab721